### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/Tools/ReadMacAddress/ReadMacAddress.ino
+++ b/examples/Tools/ReadMacAddress/ReadMacAddress.ino
@@ -10,7 +10,7 @@ WifiData EspSerial;
 String mac = "";         // a string to hold incoming data
 String ssid="";
 String espresponse="";
-boolean flag=false;
+bool flag=false;
 
 //These commands, in SLIP protocol, get the MAC Address from the ESP8266.
 char command1[]={0xc0,0x0,0xa,0x4,0x0,0x0,0x0,0x0,0x0,0x50,0x0,0xf0,0x3f,0xc0};

--- a/examples/Tools/Wifi2Serial/Wifi2Serial.ino
+++ b/examples/Tools/Wifi2Serial/Wifi2Serial.ino
@@ -13,7 +13,7 @@
 #include <UnoWiFiDevEd.h>
 
 String inputString = "";         // a string to hold incoming data
-boolean stringComplete = false;  // whether the string is complete
+bool stringComplete = false;  // whether the string is complete
 
 
 void setup() {


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633